### PR TITLE
fix test

### DIFF
--- a/examples/StreamingTests/StreamingTests.ino
+++ b/examples/StreamingTests/StreamingTests.ino
@@ -114,7 +114,7 @@ void loop()
     Assert << F("abc") == F("abc");
     Assert << String("string") == F("string");
     Assert << PrintableTest() == F("printed");
-    
+
     //
     //  Check that chaining works
     //
@@ -130,7 +130,7 @@ void loop()
     Assert << _DEC((int8_t)-1) == F("-1");
     Assert << _DEC((uint8_t)1) == F("1");
     Assert << _DEC((uint8_t)-1) == F("255");
-    
+
     Assert << _DEC((int16_t)1) == F("1");
     Assert << _DEC((int16_t)-1) == F("-1");
     Assert << _DEC((uint16_t)1) == F("1");
@@ -207,7 +207,11 @@ void loop()
 
     Assert << _FLOATW(-1,         2, 11) == F("      -1.00");
     Assert << _FLOATW(1.23456e4,  1, 11) == F("    12345.6");
+    #ifdef ARDUINO_ARCH_AVR
+    Assert << _FLOATW(-3.1415926, 6, 11) == F("  -3.141592");
+    #else
     Assert << _FLOATW(-3.1415926, 6, 11) == F("  -3.141593");
+    #endif
     Assert << _FLOATW(-9.999999,  4, 11) == F("   -10.0000");
     Assert << _FLOATW(-0.0,       1, 11) == F("        0.0");
     Assert << _FLOATW(-0.01,      1, 11) == F("       -0.0");
@@ -253,7 +257,7 @@ void loop()
     //
     // Ensure streaming template overide doesn't pass by value
     //
-    Assert 
+    Assert
         << NoCopyConstructorType()
         == F("NoCopyCtr");
 


### PR DESCRIPTION
```
    #ifdef ARDUINO_ARCH_AVR
    Assert << _FLOATW(-3.1415926, 6, 11) == F("  -3.141592");
    #else
    Assert << _FLOATW(-3.1415926, 6, 11) == F("  -3.141593");
    #endif
```
verification strings were only 10 chars long